### PR TITLE
feat: export datalayer service

### DIFF
--- a/projects/ngx-piwik-pro/src/public-api.ts
+++ b/projects/ngx-piwik-pro/src/public-api.ts
@@ -23,6 +23,7 @@ export * from './lib/services/download-and-outlink/download-and-outlink.service'
 export * from './lib/services/e-commerce/e-commerce.service';
 export * from './lib/services/goal-conversions/goal-conversions.service';
 export * from './lib/services/user-management/user-management.service';
+export * from './lib/services/data-layer/data-layer.service';
 
 export * from './lib/tokens/ngx-paq-token';
 export * from './lib/tokens/ngx-piwik-pro-settings.token';


### PR DESCRIPTION
Data layer service is not declared in the public-api file, so is not useable outside of this library. According to the readme, the data layer service should be part of the public-api