### PR TITLE
Replaced `piwik-pro-angular-tracking` (package.json=>name) by proper package name `@piwikpro/ngx-piwik-pro` (as it's known by npmjs Registry)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /out-tsc
 # Only exists if Bazel was run
 /bazel-out
+.angular
 
 # dependencies
 /node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "piwik-pro-angular-tracking",
+  "name": "@piwikpro/ngx-piwik-pro",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "piwik-pro-angular-tracking",
+  "name": "@piwikpro/ngx-piwik-pro",
   "version": "0.0.5",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
Maybe it's a reason of Issue #12

NPMjs.com clearly does hve ONLY one package with name `@piwikpro/ngx-piwik-pro`
https://www.npmjs.com/package/@piwikpro/ngx-piwik-pro

Bit this package is ALSO searchable by value `piwik-pro-angular-tracking`

When we install `piwik-pro-angular-tracking` LOCALLY it installs totally different package:

![image](https://user-images.githubusercontent.com/85486996/220635968-ac375adb-792c-4257-b5a6-2f56656e7b82.png)

And contains ONLY two files:
![image](https://user-images.githubusercontent.com/85486996/220636021-12005682-bcb3-45f9-b6f6-6fcd9491cc1e.png)

README:
```
# Security holding package

This package contained malicious code and was removed from the registry by the npm security team. A placeholder was published to ensure users are not affected in the future.

Please refer to www.npmjs.com/advisories?search=piwik-pro-angular-tracking for more information.
```

`package.json`:

```
{
  "name": "piwik-pro-angular-tracking",
  "version": "0.0.1-security",
  "description": "security holding package",
  "repository": "npm/security-holder"
}

```

So the idea of this PR is TO AVOPID using that name whatsoever. 

**DISCLAIMER.
I don't know the history of these both packages. I am NOT maintainer.**


Git Hub Actions result from MY fork:
![image](https://user-images.githubusercontent.com/85486996/220636537-53cb422b-bdf6-4c89-8e84-e5b9df209b0c.png)

