### PR TITLE
Move base tracking library to the package directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@piwikpro/tracking-base-library": "^1.1.2",
         "rxjs": "~7.8.1",
         "tslib": "^2.6.2",
         "zone.js": "^0.14.6"
@@ -4401,14 +4400,6 @@
       },
       "engines": {
         "node": "^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@piwikpro/tracking-base-library": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@piwikpro/tracking-base-library/-/tracking-base-library-1.1.2.tgz",
-      "integrity": "sha512-zOfDgtZEHujQOeLvq6IctXbJpIY+mixDgEnGR/4yc72g2vKaIf8g6N4P8jGREYUovBVwcrwh99fIP9V+dsrtBA==",
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@piwikpro/tracking-base-library": "^1.1.2",
     "rxjs": "~7.8.1",
     "tslib": "^2.6.2",
     "zone.js": "^0.14.6"

--- a/projects/ngx-piwik-pro/package-lock.json
+++ b/projects/ngx-piwik-pro/package-lock.json
@@ -16,7 +16,8 @@
       },
       "peerDependencies": {
         "@angular/common": ">=13.2.0",
-        "@angular/core": ">=13.2.0"
+        "@angular/core": ">=13.2.0",
+        "@piwikpro/tracking-base-library": "^1.1.2"
       }
     },
     "node_modules/@angular/common": {
@@ -49,6 +50,16 @@
       "peerDependencies": {
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.14.0"
+      }
+    },
+    "node_modules/@piwikpro/tracking-base-library": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@piwikpro/tracking-base-library/-/tracking-base-library-1.2.0.tgz",
+      "integrity": "sha512-D3F29v0D77vPHGeVognfLYWrP/K6SfnukWERelxsiduFuRWPbKagMLqMxsxnw81QURhSy/CngAmjPBAM1jXAjg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/rxjs": {

--- a/projects/ngx-piwik-pro/package.json
+++ b/projects/ngx-piwik-pro/package.json
@@ -21,7 +21,8 @@
   "homepage": "https://github.com/PiwikPRO/ngx-piwik-pro#readme",
   "peerDependencies": {
     "@angular/common": ">=13.2.0",
-    "@angular/core": ">=13.2.0"
+    "@angular/core": ">=13.2.0",
+    "@piwikpro/tracking-base-library": "^1.1.2"
   },
   "dependencies": {
     "tslib": "^2.6.2"


### PR DESCRIPTION
`@piwikpro/tracking-base-library` was missing in package build.
This PR moves this dependency as a peer dependency into the package directory