### PR TITLE
[PPI-1511] - add new methods for download classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+- [2.6.0](#260)
 - [2.5.0](#250)
 - [2.4.0](#240)
 - [2.3.0](#230)
@@ -10,6 +11,9 @@
 - [1.1.0](#110)
 - [1.0.0](#100)
 - [0.0.1](#001)
+
+## 2.6.0
+- bump `@piwikpro/tracking-base-library` - add new methods for download classes
 
 ## 2.5.0
 - add ssr support

--- a/README.md
+++ b/README.md
@@ -1231,9 +1231,12 @@ Adds entry to a data layer
 
 
 
+- [addDownloadClasses](#namespacesdownloadandoutlinkfunctionsadddownloadclassesmd)
 - [addDownloadExtensions](#namespacesdownloadandoutlinkfunctionsadddownloadextensionsmd)
 - [enableLinkTracking](#namespacesdownloadandoutlinkfunctionsenablelinktrackingmd)
+- [getDownloadClasses](#namespacesdownloadandoutlinkfunctionsgetdownloadclassesmd)
 - [getLinkTrackingTimer](#namespacesdownloadandoutlinkfunctionsgetlinktrackingtimermd)
+- [removeDownloadClasses](#namespacesdownloadandoutlinkfunctionsremovedownloadclassesmd)
 - [removeDownloadExtensions](#namespacesdownloadandoutlinkfunctionsremovedownloadextensionsmd)
 - [setDownloadClasses](#namespacesdownloadandoutlinkfunctionssetdownloadclassesmd)
 - [setDownloadExtensions](#namespacesdownloadandoutlinkfunctionssetdownloadextensionsmd)
@@ -1241,6 +1244,27 @@ Adds entry to a data layer
 - [setLinkClasses](#namespacesdownloadandoutlinkfunctionssetlinkclassesmd)
 - [setLinkTrackingTimer](#namespacesdownloadandoutlinkfunctionssetlinktrackingtimermd)
 - [trackLink](#namespacesdownloadandoutlinkfunctionstracklinkmd)
+
+
+<a name="namespacesdownloadandoutlinkfunctionsadddownloadclassesmd"></a>
+
+
+***
+
+
+## addDownloadClasses()
+
+> **addDownloadClasses**(`classes`): `void`
+
+Adds new classes to the download classes list
+
+### Parameters
+
+• **classes**: `string`[]
+
+### Returns
+
+`void`
 
 
 <a name="namespacesdownloadandoutlinkfunctionsadddownloadextensionsmd"></a>
@@ -1288,6 +1312,23 @@ to a downloadable file creates a download event
 `void`
 
 
+<a name="namespacesdownloadandoutlinkfunctionsgetdownloadclassesmd"></a>
+
+
+***
+
+
+## getDownloadClasses()
+
+> **getDownloadClasses**(): `Promise`\<`string`[]\>
+
+Returns list of download classes (CSS classes that indicate a link is a download)
+
+### Returns
+
+`Promise`\<`string`[]\>
+
+
 <a name="namespacesdownloadandoutlinkfunctionsgetlinktrackingtimermd"></a>
 
 
@@ -1303,6 +1344,27 @@ Returns lock/wait time after a request set by setLinkTrackingTimer
 ### Returns
 
 `Promise`\<`number`\>
+
+
+<a name="namespacesdownloadandoutlinkfunctionsremovedownloadclassesmd"></a>
+
+
+***
+
+
+## removeDownloadClasses()
+
+> **removeDownloadClasses**(`classes`): `void`
+
+Removes classes from the download classes list
+
+### Parameters
+
+• **classes**: `string`[]
+
+### Returns
+
+`void`
 
 
 <a name="namespacesdownloadandoutlinkfunctionsremovedownloadextensionsmd"></a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4005,9 +4005,9 @@
       "link": true
     },
     "node_modules/@piwikpro/tracking-base-library": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@piwikpro/tracking-base-library/-/tracking-base-library-1.6.0.tgz",
-      "integrity": "sha512-jd88qqxGAtjSfdDLPuFzrk1hjnIQKCdSFynm3GE/fHB0drPsXZ/o1oXPY9YpAVX2dIkurrycRAzEhtC6KwSlfw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@piwikpro/tracking-base-library/-/tracking-base-library-1.7.0.tgz",
+      "integrity": "sha512-0u5YTcYO2As9T6ZFuJn0da6VYWz0sVYFFujkwiD8fz0o+Jjvl8r8Fk7rM2/ifLs03bqBOYe8MZRCjDKHWQzaiQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -17995,10 +17995,10 @@
     },
     "projects/ngx-piwik-pro": {
       "name": "@piwikpro/ngx-piwik-pro",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
-        "@piwikpro/tracking-base-library": "^1.6.0"
+        "@piwikpro/tracking-base-library": "^1.7.0"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -58,5 +58,7 @@
     "typedoc-plugin-markdown": "^4.2.9",
     "typescript": "^5.5.4"
   },
-  "workspaces": ["projects/ngx-piwik-pro"]
+  "workspaces": [
+    "projects/ngx-piwik-pro"
+  ]
 }

--- a/projects/ngx-piwik-pro/package.json
+++ b/projects/ngx-piwik-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piwikpro/ngx-piwik-pro",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Piwik PRO tracking library for Angular apps.",
   "keywords": [
     "PiwikPRO",
@@ -24,6 +24,6 @@
     "@angular/core": ">=13.2.0"
   },
   "dependencies": {
-    "@piwikpro/tracking-base-library": "^1.6.0"
+    "@piwikpro/tracking-base-library": "^1.7.0"
   }
 }

--- a/projects/ngx-piwik-pro/src/lib/services/download-and-outlink/download-and-outlink.service.ts
+++ b/projects/ngx-piwik-pro/src/lib/services/download-and-outlink/download-and-outlink.service.ts
@@ -1,4 +1,4 @@
-import { Dimensions, DownloadAndOutlink } from '@piwikpro/tracking-base-library'
+import { DownloadAndOutlink } from '@piwikpro/tracking-base-library'
 
 import { Injectable } from '@angular/core';
 
@@ -17,9 +17,6 @@ export class DownloadAndOutlinkService {
   setLinkClasses(...params: Parameters<IDownloadAndOutlink['setLinkClasses']>) {
     DownloadAndOutlink.setLinkClasses(...params);
   }
-  setDownloadClasses(...params: Parameters<IDownloadAndOutlink['setDownloadClasses']>) {
-    DownloadAndOutlink.setDownloadClasses(...params);
-  }
   setDownloadExtensions(...params: Parameters<IDownloadAndOutlink['setDownloadExtensions']>) {
     DownloadAndOutlink.setDownloadExtensions(...params);
   }
@@ -37,5 +34,17 @@ export class DownloadAndOutlinkService {
   }
   setIgnoreClasses(...params: Parameters<IDownloadAndOutlink['setIgnoreClasses']>) {
     DownloadAndOutlink.setIgnoreClasses(...params);
+  }
+  getDownloadClasses(...params: Parameters<IDownloadAndOutlink['getDownloadClasses']>) {
+    return DownloadAndOutlink.getDownloadClasses(...params);
+  }
+  setDownloadClasses(...params: Parameters<IDownloadAndOutlink['setDownloadClasses']>) {
+    DownloadAndOutlink.setDownloadClasses(...params);
+  }
+  addDownloadClasses(...params: Parameters<IDownloadAndOutlink['addDownloadClasses']>) {
+    DownloadAndOutlink.addDownloadClasses(...params);
+  }
+  removeDownloadClasses(...params: Parameters<IDownloadAndOutlink['removeDownloadClasses']>) {
+    DownloadAndOutlink.removeDownloadClasses(...params);
   }
 }

--- a/projects/ngx-piwik-pro/src/version.ts
+++ b/projects/ngx-piwik-pro/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "2.4.0"
+export const VERSION = "2.6.0"


### PR DESCRIPTION
Bumps tracking-base-library and this package's version to prepare for new release

**Note: this PR bumps ngx-piwik-pro to 2.6.0**