### PR TITLE
feat: add missing tracking-base-library methods to Angular services

### DIFF
--- a/projects/ngx-piwik-pro/src/lib/public-api.spec.ts
+++ b/projects/ngx-piwik-pro/src/lib/public-api.spec.ts
@@ -11,6 +11,7 @@ import { CustomEventsService } from './services/custom-event/custom-events.servi
 import { DataLayerService } from './services/data-layer/data-layer.service';
 import { DownloadAndOutlinkService } from './services/download-and-outlink/download-and-outlink.service';
 import { ECommerceService } from './services/e-commerce/e-commerce.service';
+import { ErrorTrackingService } from './services/error-tracking/error-tracking.service';
 import { GoalConversionsService } from './services/goal-conversions/goal-conversions.service';
 import { HeartbeatService } from './services/heartbeat/heartbeat.service';
 import { MiscellaneousService } from './services/miscellaneous/miscellaneous.service';
@@ -27,6 +28,7 @@ const EXPECTED_SERVICES: ReadonlyArray<readonly [string, Type<unknown>]> = [
   ['CustomDimensionsService', CustomDimensionsService],
   ['DownloadAndOutlinkService', DownloadAndOutlinkService],
   ['ECommerceService', ECommerceService],
+  ['ErrorTrackingService', ErrorTrackingService],
   ['GoalConversionsService', GoalConversionsService],
   ['SiteSearchService', SiteSearchService],
   ['UserManagementService', UserManagementService],

--- a/projects/ngx-piwik-pro/src/lib/services/cookie-management/cookie-management.service.ts
+++ b/projects/ngx-piwik-pro/src/lib/services/cookie-management/cookie-management.service.ts
@@ -25,8 +25,14 @@ export class CookieManagementService {
   setCookieDomain(...params: Parameters<ICookieManagement['setCookieDomain']>) {
     CookieManagement.setCookieDomain(...params);
   }
+  getCookieDomain() {
+    return CookieManagement.getCookieDomain();
+  }
   setCookiePath(...params: Parameters<ICookieManagement['setCookiePath']>) {
     CookieManagement.setCookiePath(...params);
+  }
+  getCookiePath() {
+    return CookieManagement.getCookiePath();
   }
   setSecureCookie(...params: Parameters<ICookieManagement['setSecureCookie']>) {
     CookieManagement.setSecureCookie(...params);
@@ -34,8 +40,17 @@ export class CookieManagementService {
   setVisitorCookieTimeout(...params: Parameters<ICookieManagement['setVisitorCookieTimeout']>) {
     CookieManagement.setVisitorCookieTimeout(...params);
   }
+  getConfigVisitorCookieTimeout() {
+    return CookieManagement.getConfigVisitorCookieTimeout();
+  }
   setSessionCookieTimeout(...params: Parameters<ICookieManagement['setSessionCookieTimeout']>) {
     CookieManagement.setSessionCookieTimeout(...params);
+  }
+  getSessionCookieTimeout() {
+    return CookieManagement.getSessionCookieTimeout();
+  }
+  setReferralCookieTimeout(...params: Parameters<ICookieManagement['setReferralCookieTimeout']>) {
+    CookieManagement.setReferralCookieTimeout(...params);
   }
   setVisitorIdCookie(...params: Parameters<ICookieManagement['setVisitorIdCookie']>) {
     CookieManagement.setVisitorIdCookie(...params);

--- a/projects/ngx-piwik-pro/src/lib/services/data-layer/data-layer.service.ts
+++ b/projects/ngx-piwik-pro/src/lib/services/data-layer/data-layer.service.ts
@@ -7,6 +7,9 @@ type IDataLayer = typeof DataLayer;
   providedIn: 'root'
 })
 export class DataLayerService {
+  setDataLayerName(...params: Parameters<IDataLayer['setDataLayerName']>) {
+    DataLayer.setDataLayerName(...params);
+  }
   push(...params: Parameters<IDataLayer['push']>) {
     return DataLayer.push(...params);
   }

--- a/projects/ngx-piwik-pro/src/lib/services/error-tracking/error-tracking.service.ts
+++ b/projects/ngx-piwik-pro/src/lib/services/error-tracking/error-tracking.service.ts
@@ -1,0 +1,16 @@
+import { ErrorTracking } from '@piwikpro/tracking-base-library';
+import { Injectable } from '@angular/core';
+
+type IErrorTracking = typeof ErrorTracking;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ErrorTrackingService {
+  enableJSErrorTracking(...params: Parameters<IErrorTracking['enableJSErrorTracking']>) {
+    ErrorTracking.enableJSErrorTracking(...params);
+  }
+  trackError(...params: Parameters<IErrorTracking['trackError']>) {
+    ErrorTracking.trackError(...params);
+  }
+}

--- a/projects/ngx-piwik-pro/src/public-api.ts
+++ b/projects/ngx-piwik-pro/src/public-api.ts
@@ -21,6 +21,7 @@ export * from './lib/services/site-search/site-search.service';
 export * from './lib/services/custom-event/custom-events.service';
 export * from './lib/services/download-and-outlink/download-and-outlink.service';
 export * from './lib/services/e-commerce/e-commerce.service';
+export * from './lib/services/error-tracking/error-tracking.service';
 export * from './lib/services/goal-conversions/goal-conversions.service';
 export * from './lib/services/user-management/user-management.service';
 export * from './lib/services/data-layer/data-layer.service';


### PR DESCRIPTION
Angular is the only web SDK that does not automatically reexport tracking-base-library, so 8 methods were never added. All of them exist in the already-installed tracking-base-library@1.7.1 - no core library release is required.